### PR TITLE
Revert "Bug 1208563: inIncognitoContext is unsupported"

### DIFF
--- a/browsersupport-chrome.js
+++ b/browsersupport-chrome.js
@@ -183,10 +183,8 @@ RESUtils.runtime.addURLToHistory = (function() {
 	var original = RESUtils.runtime.addURLToHistory;
 
 	return function(url) {
-		// See Bug 1208563
-		// Skip when isIncognitoContext is true || undefined
-		if (chrome.extension.inIncognitoContext !== false) {
-			return
+		if (chrome.extension.inIncognitoContext) {
+			return;
 		}
 
 		original(url);


### PR DESCRIPTION
This reverts commit f9b1dc2132bd171da5e6df43f5d7638546e52297.

inIncognitoContext is not actually unsupported, but was just undocumented.
